### PR TITLE
Changed and added some public function

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -33,7 +33,7 @@ impl KcpNoDelayConfig {
     /// 2. Set ticking interval to be 10ms
     /// 3. Set fast resend to be 2
     /// 4. Disable congestion control
-    pub fn fastest() -> KcpNoDelayConfig {
+    pub const fn fastest() -> KcpNoDelayConfig {
         KcpNoDelayConfig {
             nodelay: true,
             interval: 10,
@@ -48,7 +48,7 @@ impl KcpNoDelayConfig {
     /// 2. Set ticking interval to be 40ms
     /// 3. Disable fast resend
     /// 4. Enable congestion control
-    pub fn normal() -> KcpNoDelayConfig {
+    pub const fn normal() -> KcpNoDelayConfig {
         KcpNoDelayConfig {
             nodelay: false,
             interval: 40,

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -142,6 +142,7 @@ impl KcpStream {
         future::poll_fn(|cx| self.poll_recv(cx, buf)).await
     }
 
+    /// Get the `KcpSession` for this `KcpStream`
     pub fn session(&self) -> &KcpSession {
         &self.session
     }

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -141,6 +141,10 @@ impl KcpStream {
     pub async fn recv(&mut self, buf: &mut [u8]) -> KcpResult<usize> {
         future::poll_fn(|cx| self.poll_recv(cx, buf)).await
     }
+
+    pub fn session(&self) -> &KcpSession {
+        &self.session
+    }
 }
 
 impl AsyncRead for KcpStream {


### PR DESCRIPTION
There are 2 changes in this pull reuqest.
1. For const-context use of the associated function in KcpNoDelayConfig, the associated function is now const.
2. For accessing some Kcp API functions, expose session in KcpStream.

In fact, the cause of the second change is that I just need the KcpSocket to access Kcp to get the window situation. I don't know if it is correct to access session in the KcpStream. Thanks for your time reviewing my pull request