### PR TITLE
fix: KCP session is closing while listener tries to input #30

### DIFF
--- a/src/listener.rs
+++ b/src/listener.rs
@@ -120,7 +120,9 @@ impl KcpListener {
                                 // if let Err(err) = kcp.input(packet) {
                                 //     error!("kcp.input failed, peer: {}, conv: {}, error: {}, packet: {:?}", peer_addr, conv, err, ByteStr::new(packet));
                                 // }
-                                session.input(packet).await;
+                                if session.input(packet).await.is_err() {
+                                    trace!("[SESSION] KCP session is closing while listener tries to input");
+                                }
                             }
                         }
                     }

--- a/src/session.rs
+++ b/src/session.rs
@@ -255,8 +255,8 @@ impl KcpSession {
         self.notify();
     }
 
-    pub async fn input(&self, buf: &[u8]) {
-        self.input_tx.send(buf.to_owned()).await.expect("input channel closed")
+    pub async fn input(&self, buf: &[u8]) -> Result<(), SessionClosedError> {
+        self.input_tx.send(buf.to_owned()).await.map_err(|_| SessionClosedError)
     }
 
     pub async fn conv(&self) -> u32 {
@@ -268,6 +268,8 @@ impl KcpSession {
         self.notifier.notify_one();
     }
 }
+
+pub struct SessionClosedError;
 
 struct KcpSessionUniq(Arc<KcpSession>);
 


### PR DESCRIPTION
Fixed: https://github.com/Matrix-Zhang/tokio_kcp/issues/30

Previously, when the session is closing but not yet removed from the list, the listener might send input in that session. But that function call will hit a panic.

After this change, if that happens, the dying session will return an error to the listener instead of instantly panic.
