### PR TITLE
Update Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ log = "0.4"
 tokio = { version = "1.11", features = ["net", "sync", "rt", "macros", "time"] }
 byte_string = "1"
 rand = "0.8"
-spin = "0.9"
+spin = "0.9.8"
 
 [dev-dependencies]
 env_logger = "0.10"


### PR DESCRIPTION
Updates dependency to the patch version of 0.9.8

[Advisory](https://rustsec.org/advisories/RUSTSEC-2023-0031.html)